### PR TITLE
feat: add windows support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,6 @@ name: Build Moddable tooling
 
 on:
   push:
-    branches:
-      - 'windows-support'
     tags:
       - '*'
   workflow_dispatch:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,6 +36,8 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      - uses: ilammy/msvc-dev-cmd@v1
+      
       - name: Clone and build tooling
         uses: ./
         id: prebuild

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,8 @@ name: Build Moddable tooling
 
 on:
   push:
+    branches:
+      - 'windows-support'
     tags:
       - '*'
   workflow_dispatch:
@@ -18,7 +20,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     
     steps:

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ async function run() {
     if (platform === "win") {
       await exec("dir", [], { cwd: BUILD_DIR });
     }
-    await exec(platform === "win" ? "build.bat" : "make", [], { cwd: BUILD_DIR });
+    await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;
 

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,8 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("echo %PATH%", [], { cwd: BUILD_DIR });
+      await exec("%PATH%", [], { cwd: BUILD_DIR });
+      process.env.COMSPEC = "pwsh.EXE";
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -11,8 +11,9 @@ const MODDABLE_REPO = "https://github.com/Moddable-OpenSource/moddable";
 const pipe = promisify(pipeline);
 
 const PLATFORMS: Record<string, string> = {
-  Darwin: "mac",
-  Linux: "lin",
+  darwin: "mac",
+  linux: "lin",
+  win32: "win"
 };
 
 async function gzipBuild(input: string, output: string) {
@@ -24,7 +25,7 @@ async function gzipBuild(input: string, output: string) {
 async function run() {
   try {
     const commit = core.getInput("commit");
-    const platform = PLATFORMS[platformType()];
+    const platform = PLATFORMS[platformType().toLowerCase()];
     const arch = process.arch;
 
     if (platform === "lin") {

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("echo $env:PATH", [], { cwd: BUILD_DIR });
+      await exec("echo %PATH%", [], { cwd: BUILD_DIR });
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ async function run() {
       await exec("git", ["checkout", commit], { cwd: process.env.MODDABLE });
     }
 
-    core.info(`Set BUILD_DIR variable: ${process.env.MODDABLE}, ${platform}, ${platformType()}`);
+    core.info(`Set BUILD_DIR variable`);
     const BUILD_DIR = resolve(
       process.env.MODDABLE,
       "build",
@@ -69,7 +69,7 @@ async function run() {
       platform
     );
     core.info(`Building tools in ${BUILD_DIR}`);
-    await exec("make", [], { cwd: BUILD_DIR });
+    await exec(platform === "win" ? "build" : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;
 

--- a/index.ts
+++ b/index.ts
@@ -51,20 +51,24 @@ async function run() {
 
     core.info("Cloning Moddable-OpenSource/moddable repo");
     await exec("git", ["clone", MODDABLE_REPO], { shell: platform === 'win' });
+    core.info("Cloning complete");
 
     process.env.MODDABLE = join(process.cwd(), "moddable");
+    core.info("Set MODDABLE env variable");
 
     if (commit && commit !== "latest") {
       core.info(`Checking out commit: ${commit}`);
       await exec("git", ["checkout", commit], { cwd: process.env.MODDABLE });
     }
 
+    core.info("Set BUILD_DIR variable");
     const BUILD_DIR = resolve(
       process.env.MODDABLE,
       "build",
       "makefiles",
       platform
     );
+    core.info(`Building tools in ${BUILD_DIR}`);
     await exec("make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;

--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ async function run() {
     core.info(`Building tools for ${platform}`);
 
     core.info("Cloning Moddable-OpenSource/moddable repo");
-    await exec("git", ["clone", MODDABLE_REPO]);
+    await exec("git", ["clone", MODDABLE_REPO], { shell: platform === 'win' });
 
     process.env.MODDABLE = join(process.cwd(), "moddable");
 

--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,7 @@ async function run() {
     if (platform === "win") {
       await exec("dir", [], { cwd: BUILD_DIR });
     }
-    await exec(platform === "win" ? "build" : "make", [], { cwd: BUILD_DIR });
+    await exec(platform === "win" ? "build.bat" : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;
 

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("dir", [], { cwd: BUILD_DIR });
+      await exec("Write-Output $Env:PATH", [], { cwd: BUILD_DIR });
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("%PATH%", [], { cwd: BUILD_DIR });
+      // await exec("%PATH%", [], { cwd: BUILD_DIR });
       process.env.COMSPEC = "pwsh.EXE";
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });

--- a/index.ts
+++ b/index.ts
@@ -69,6 +69,7 @@ async function run() {
       platform
     );
     core.info(`Building tools in ${BUILD_DIR}`);
+    await exec("dir", [], { cwd: BUILD_DIR });
     await exec(platform === "win" ? "build" : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;

--- a/index.ts
+++ b/index.ts
@@ -70,10 +70,12 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("vcvarsall.bat x86_x64", [], { cwd: BUILD_DIR });
+      // await exec("vcvarsall.bat x86_x64", [], { cwd: BUILD_DIR });
       // process.env.COMSPEC = "devenv.exe";
+      await exec(`./build.bat`, [], { cwd: BUILD_DIR });
+    } else {
+      await exec("make", [], { cwd: BUILD_DIR });
     }
-    await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;
 

--- a/index.ts
+++ b/index.ts
@@ -13,7 +13,7 @@ const pipe = promisify(pipeline);
 const PLATFORMS: Record<string, string> = {
   darwin: "mac",
   linux: "lin",
-  win32: "win"
+  windows_nt: "win"
 };
 
 async function gzipBuild(input: string, output: string) {

--- a/index.ts
+++ b/index.ts
@@ -70,8 +70,8 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      // await exec("%PATH%", [], { cwd: BUILD_DIR });
-      process.env.COMSPEC = "pwsh.EXE";
+      // await exec("vcvarsall.bat", [], { cwd: BUILD_DIR });
+      process.env.COMSPEC = "devenv.exe";
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -70,8 +70,6 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      // await exec("vcvarsall.bat x86_x64", [], { cwd: BUILD_DIR });
-      // process.env.COMSPEC = "devenv.exe";
       await exec(`./build.bat`, [], { cwd: BUILD_DIR });
     } else {
       await exec("make", [], { cwd: BUILD_DIR });

--- a/index.ts
+++ b/index.ts
@@ -70,8 +70,8 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      // await exec("vcvarsall.bat", [], { cwd: BUILD_DIR });
-      process.env.COMSPEC = "devenv.exe";
+      await exec("vcvarsall.bat x86_x64", [], { cwd: BUILD_DIR });
+      // process.env.COMSPEC = "devenv.exe";
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -69,7 +69,9 @@ async function run() {
       platform
     );
     core.info(`Building tools in ${BUILD_DIR}`);
-    await exec("dir", [], { cwd: BUILD_DIR });
+    if (platform === "win") {
+      await exec("dir", [], { cwd: BUILD_DIR });
+    }
     await exec(platform === "win" ? "build" : "make", [], { cwd: BUILD_DIR });
 
     const artifactName = `moddable-build-tools-${platform}-${arch}.tgz`;

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("$PSVersionTable", [], { cwd: BUILD_DIR });
+      await exec("echo $env:PATH", [], { cwd: BUILD_DIR });
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -50,7 +50,7 @@ async function run() {
     core.info(`Building tools for ${platform}`);
 
     core.info("Cloning Moddable-OpenSource/moddable repo");
-    await exec("git", ["clone", MODDABLE_REPO], { shell: platform === 'win' });
+    await exec("git", ["clone", MODDABLE_REPO]);
     core.info("Cloning complete");
 
     process.env.MODDABLE = join(process.cwd(), "moddable");

--- a/index.ts
+++ b/index.ts
@@ -54,7 +54,7 @@ async function run() {
     core.info("Cloning complete");
 
     process.env.MODDABLE = join(process.cwd(), "moddable");
-    core.info("Set MODDABLE env variable");
+    core.info(`Set MODDABLE env variable: ${process.env.MODDABLE}`);
 
     if (commit && commit !== "latest") {
       core.info(`Checking out commit: ${commit}`);

--- a/index.ts
+++ b/index.ts
@@ -70,7 +70,7 @@ async function run() {
     );
     core.info(`Building tools in ${BUILD_DIR}`);
     if (platform === "win") {
-      await exec("Write-Output $Env:PATH", [], { cwd: BUILD_DIR });
+      await exec("$PSVersionTable", [], { cwd: BUILD_DIR });
     }
     await exec(platform === "win" ? `./build.bat` : "make", [], { cwd: BUILD_DIR });
 

--- a/index.ts
+++ b/index.ts
@@ -61,7 +61,7 @@ async function run() {
       await exec("git", ["checkout", commit], { cwd: process.env.MODDABLE });
     }
 
-    core.info("Set BUILD_DIR variable");
+    core.info(`Set BUILD_DIR variable: ${process.env.MODDABLE}, ${platform}, ${platformType()}`);
     const BUILD_DIR = resolve(
       process.env.MODDABLE,
       "build",


### PR DESCRIPTION
By adding the `windows_nt` option to the `PLATFORMS` record, updating the Moddable build command to `./build.bat`, and using the [`msvc-dev-cmd`](https://github.com/ilammy/msvc-dev-cmd) action for environmental setup on Windows this project can now output prebuilt tooling for Windows. 🎉 