### PR TITLE
feat: schedule daily build w/ conditions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,8 +2,10 @@ name: Build Moddable tooling
 
 on:
   push:
-    tags:
-      - '*'
+    branches:
+      - 'scheduled-builds'
+  schedule:
+    - cron: '0 2 * * *'
   workflow_dispatch:
     inputs:
       commit:
@@ -14,7 +16,27 @@ on:
 
 
 jobs:
+  check_latest_commit:
+    runs-on: ubuntu-latest
+    outputs:
+      release: ${{ steps.latest_release.outputs.release }}
+      commit: ${{ steps.latest_commit.outputs.commit }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Get latest release
+        id: latest_release
+        run: echo "::set-output name=release::$(gh release view latest --json name --jq '.name')"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+      - name: Get latest Moddable commit
+        id: latest_commit
+        run: echo "::set-output name=commit::$(gh api repos/Moddable-OpenSource/moddable/commits --jq '.[0].sha' | cut -c1-7)"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
   build_tools:
+    needs: check_latest_commit
+    if: needs.check_latest_commit.outputs.release != needs.check_latest_commit.outputs.commit
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,9 +1,6 @@
 name: Build Moddable tooling
 
 on:
-  push:
-    branches:
-      - 'scheduled-builds'
   schedule:
     - cron: '0 2 * * *'
   workflow_dispatch:


### PR DESCRIPTION
Now that 3 out of the 4 build targets are completed through CI, this PR schedules daily builds that are dependent on the latest release name from this repo compared to the latest short commit SHA from the Moddable repo. 

It would be nice to receive a notification when a new macos arm64 build is required, but hopefully this can be done through an official runner at some point. 